### PR TITLE
Make /script.js globally accessible.

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -62,7 +62,11 @@ ram.runtime = "50M"
     api.url = "/api"
     api.show_tile = false
     api.allowed = "visitors"
-    api.auth_header = false
+    api.auth_header = false 
+    script.url = "/script.js"
+    script.show_tile = false
+    script.allowed = "visitors"
+    script.auth_header = false
 
     [resources.apt]
     packages = "postgresql"


### PR DESCRIPTION
## Problem

- If you modify permission to anything but `visitors` tracking `<script>` block breaks.

## Solution

- Allow access to `/script.js` to everyone.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
