### PR TITLE
Remove current build before upgrade.

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -46,7 +46,7 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=5
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir" #--keep=".env"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 #--keep=".env"
 fi
 
 chmod -R o-rwx "$install_dir"


### PR DESCRIPTION
## Problem

As per #26 upgrade to 2.6.2 fails due to, presumably, some stale files present.

## Solution

- Remove build dir before unpacking the sources

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
