### PR TITLE
Provision pgcrypto outside of prisma migration.

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -51,6 +51,10 @@ ynh_add_config --template="../conf/.env" --destination="$install_dir/.env"
 chmod 650 "$install_dir/.env"
 chown $app:$app "$install_dir/.env"
 
+ynh_script_progression --message="Provisioning pgcrypto..." --weight=1
+
+ynh_psql_execute_as_root --sql="CREATE EXTENSION IF NOT EXISTS pgcrypto;" --database="$db_name"
+
 #=================================================
 # CONFIGURE THE APP
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -35,6 +35,8 @@ ynh_exec_warn_less ynh_install_nodejs --nodejs_version=$nodejs_version
 #=================================================
 ynh_script_progression --message="Restoring the database..." --weight=6
 
+ynh_psql_execute_as_root --sql="CREATE EXTENSION IF NOT EXISTS pgcrypto;" --database="$db_name"
+
 ynh_psql_execute_file_as_root --file="./db.sql" --database=$db_name
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -83,6 +83,10 @@ ynh_add_config --template="../conf/.env" --destination="$install_dir/.env"
 chmod 650 "$install_dir/.env"
 chown $app:$app "$install_dir/.env"
 
+ynh_script_progression --message="Provisioning pgcrypto..." --weight=1
+
+ynh_psql_execute_as_root --sql="CREATE EXTENSION IF NOT EXISTS pgcrypto;" --database="$db_name"
+
 #=================================================
 # CONFIGURE THE APP
 #=================================================
@@ -92,7 +96,6 @@ pushd $install_dir
 	ynh_use_nodejs
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH NEXT_TELEMETRY_DISABLED=1 yarn build
-	#ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH npx @umami/migrate-v1-v2@latest
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem

- In `install` `prisma` fails to provision `pgcrypto` as noted in #14 and #29

## Solution

- Provision `pgcrypto` manually as some claim it's unwise to mix together DDL and DML which `prisma` seems to do.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
