### PR TITLE
Upgrade to 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Umami is a simple, easy to use, self-hosted web analytics solution. The goal is 
 - Privacy-focused
 
 
-**Shipped version:** 2.6.2~ynh4
+**Shipped version:** 2.7.0~ynh4
 
 **Demo:** https://app.umami.is/share/8rmHaheU/umami.is
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -31,7 +31,7 @@ Umami is a simple, easy to use, self-hosted web analytics solution. The goal is 
 - Privacy-focused
 
 
-**Version incluse :** 2.6.2~ynh4
+**Version incluse :** 2.7.0~ynh4
 
 **Démo :** https://app.umami.is/share/8rmHaheU/umami.is
 

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -10,7 +10,8 @@ WorkingDirectory=__INSTALL_DIR__/
 Environment=NODE_ENV=production
 Environment="__YNH_NODE_LOAD_PATH__"
 Environment=NEXT_TELEMETRY_DISABLED=1
-ExecStart=__YNH_NPM__ run start-env
+Environment=PORT=__PORT__
+ExecStart=__YNH_NPM__ exec next start
 
 # Sandboxing options to harden security
 # Depending on specificities of your service/app, you may need to tweak these

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Umami"
 description.en = "Simple, fast, privacy-focused alternative to Google Analytics"
 description.fr = "Analyse de trafic web simple et respectueux"
 
-version = "2.6.2~ynh4"
+version = "2.7.0~ynh4"
 
 maintainers = ["eric_G"]
 
@@ -47,8 +47,8 @@ ram.runtime = "50M"
 
         [resources.sources.main]
 
-        url = "https://github.com/mikecao/umami/archive/refs/tags/v2.6.2.tar.gz"
-        sha256 = "2de79139a51b9330e0dfa12b5be0f7baaf86457370a3d30a475c0b50549a199e"
+        url = "https://github.com/mikecao/umami/archive/refs/tags/v2.7.0.tar.gz"
+        sha256 = "e3eda26825c93dda637a21b5b6cb8f6ece337e9cc2680e619e5aa23a09e8e079"
         autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]


### PR DESCRIPTION
## Problem

- Upgrade to 2.7.0
- #34 displays `Next.js` upgrade artifacts.

## Solution

- Fix systemd integration

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
