### PR TITLE
fix: Encode database password in Umami URL

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -25,6 +25,10 @@ ynh_config_add --template=".env" --destination="$install_dir/build/.env"
 
 chmod 650 "$install_dir/build/.env"
 
+db_pwd_escaped=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$db_pwd")
+database_url="postgresql://$db_user:$db_pwd_escaped@127.0.0.1:5432/$db_name"
+ynh_replace_string --match_string="^DATABASE_URL=.*" --replace_string="DATABASE_URL=$database_url" --target_file="$install_dir/build/.env"
+
 ynh_script_progression "Provisioning pgcrypto..."
 
 ynh_psql_db_shell <<< "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
@@ -53,12 +57,12 @@ pushd "$install_dir/build"
 	
 	ynh_hide_warnings ynh_exec_as_app pnpm install --frozen-lockfile --os linux --libc glibc
 	cp docker/middleware.ts src
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run build-db
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run build-tracker 
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run build-geo
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run build-app
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run check-db
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run update-tracker
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run build-db
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run build-tracker
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run build-geo
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run build-app
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run check-db
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run update-tracker
 	ynh_safe_rm "$install_dir/build/node_modules/"
 	
 	# Actual app is a subset of release assets

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -52,6 +52,10 @@ ynh_config_add --template=".env" --destination="$install_dir/build/.env"
 
 chmod 650 "$install_dir/build/.env"
 
+db_pwd_escaped=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$db_pwd")
+database_url="postgresql://$db_user:$db_pwd_escaped@127.0.0.1:5432/$db_name"
+ynh_replace_string --match_string="^DATABASE_URL=.*" --replace_string="DATABASE_URL=$database_url" --target_file="$install_dir/build/.env"
+
 ynh_script_progression "Provisioning pgcrypto..."
 
 ynh_psql_db_shell <<< "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
@@ -78,12 +82,12 @@ pushd "$install_dir/build"
 	
 	ynh_hide_warnings ynh_exec_as_app pnpm install --frozen-lockfile --os linux --libc glibc
 	cp docker/middleware.ts src
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run build-db
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run build-tracker 
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run build-geo
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run build-app
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run check-db
-	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="postgresql://$db_user:$db_pwd@localhost:5432/$db_name" npm run update-tracker
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run build-db
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run build-tracker
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run build-geo
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run build-app
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run check-db
+	ynh_hide_warnings ynh_exec_as_app env NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DATABASE_URL="$database_url" npm run update-tracker
 	ynh_safe_rm "$install_dir/build/node_modules/"
 	
 	# Actual app is a subset of release assets


### PR DESCRIPTION
Encode the generated PostgreSQL password before building DATABASE_URL so reserved characters do not break Prisma authentication during install and upgrade.

## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
