### PR TITLE
Fix pnpm incompatibility

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -49,7 +49,7 @@ ynh_script_progression "Configuring and building the app..."
 pushd "$install_dir/build"
 	corepack enable
     ynh_hide_warnings npm install -g corepack@latest
-    ynh_hide_warnings corepack prepare pnpm@10.25.0 --activate
+    ynh_hide_warnings ynh_exec_as_app corepack prepare pnpm@latest-10 --activate
 	
 	ynh_hide_warnings ynh_exec_as_app pnpm install --frozen-lockfile --os linux --libc glibc
 	cp docker/proxy.ts src

--- a/scripts/install
+++ b/scripts/install
@@ -49,7 +49,7 @@ ynh_script_progression "Configuring and building the app..."
 pushd "$install_dir/build"
 	corepack enable
     ynh_hide_warnings npm install -g corepack@latest
-    ynh_hide_warnings corepack prepare  pnpm@latest --activate
+    ynh_hide_warnings corepack prepare pnpm@latest-10 --activate
 	
 	ynh_hide_warnings ynh_exec_as_app pnpm install --frozen-lockfile --os linux --libc glibc
 	cp docker/proxy.ts src

--- a/scripts/install
+++ b/scripts/install
@@ -49,7 +49,7 @@ ynh_script_progression "Configuring and building the app..."
 pushd "$install_dir/build"
 	corepack enable
     ynh_hide_warnings npm install -g corepack@latest
-    ynh_hide_warnings corepack prepare pnpm@latest-10 --activate
+    ynh_hide_warnings corepack prepare pnpm@10.25.0 --activate
 	
 	ynh_hide_warnings ynh_exec_as_app pnpm install --frozen-lockfile --os linux --libc glibc
 	cp docker/proxy.ts src

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,7 +74,7 @@ ynh_script_progression "Configuring the app..."
 pushd "$install_dir/build"
 	corepack enable
     ynh_hide_warnings npm install -g corepack@latest
-    ynh_hide_warnings corepack prepare  pnpm@latest --activate
+    ynh_hide_warnings corepack prepare pnpm@latest-10 --activate
 	
 	ynh_hide_warnings ynh_exec_as_app pnpm install --frozen-lockfile --os linux --libc glibc
 	cp docker/proxy.ts src

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,7 +74,7 @@ ynh_script_progression "Configuring the app..."
 pushd "$install_dir/build"
 	corepack enable
     ynh_hide_warnings npm install -g corepack@latest
-    ynh_hide_warnings corepack prepare pnpm@10.25.0 --activate
+    ynh_hide_warnings ynh_exec_as_app corepack prepare pnpm@latest-10 --activate
 	
 	ynh_hide_warnings ynh_exec_as_app pnpm install --frozen-lockfile --os linux --libc glibc
 	cp docker/proxy.ts src

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,7 +74,7 @@ ynh_script_progression "Configuring the app..."
 pushd "$install_dir/build"
 	corepack enable
     ynh_hide_warnings npm install -g corepack@latest
-    ynh_hide_warnings corepack prepare pnpm@latest-10 --activate
+    ynh_hide_warnings corepack prepare pnpm@10.25.0 --activate
 	
 	ynh_hide_warnings ynh_exec_as_app pnpm install --frozen-lockfile --os linux --libc glibc
 	cp docker/proxy.ts src


### PR DESCRIPTION
## Problem
Context is #120 

Tl;Dr:
* pnpm:latest points to 11 (now?)
* pnpm 11 changed the onlyBuiltDependencies config to allowBuilds: https://pnpm.io/next/settings#allowbuilds
* umami still has it's configuration in v10 format
* install/restore fail
* to fix I pinned pnpm to v10
* because the pinned version was not seen during installation I also added ynh_exec_as_app to the line

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)